### PR TITLE
Fixed links to lessons on start page

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,13 @@ In Unit 1, you will learn the fundamentals of RavenDB.
 
 First, you will learn how to install and make it work on your machine. As you will see, RavenDB makes starting easy by providing an embedded sample database – if you think "Northwind", you are right! – which you can use for your learning process with minimal effort. Then, you will write some code to connect to the database and quickly store, load, modify and delete documents.
 
-* [Lesson 1: Getting Started](src/unit1/lesson1)
-* [Lesson 2: It is querying time!](src/unit1/lesson2)
-* [Lesson 3: Let's code](src/unit1/lesson3)
-* [Lesson 4: Basics of DocumentStore](src/unit1/lesson4)
-* [Lesson 5: Loading Documents](src/unit1/lesson5)
-* [Lesson 6: Querying fundamentals in the C# side] (src/unit1/lesson6)
-* [Lesson 7: Storing, modifying and deleting documents](src/unit1/lesson7)
+* [Lesson 1: Getting Started](src/Unit-1/lesson1)
+* [Lesson 2: It is querying time!](src/Unit-1/lesson2)
+* [Lesson 3: Let's code](src/Unit-1/lesson3)
+* [Lesson 4: Basics of DocumentStore](src/Unit-1/lesson4)
+* [Lesson 5: Loading Documents](src/Unit-1/lesson5)
+* [Lesson 6: Querying fundamentals in the C# side] (src/Unit-1/lesson6)
+* [Lesson 7: Storing, modifying and deleting documents](src/Unit-1/lesson7)
 
 ### Unit 2 - Beyond the basics
 
@@ -36,12 +36,12 @@ In Unit 2, you are going to learn intermediate RavenDB features. You will see ho
 
 You will learn that you can easily perform very complex queries using only RavenDB (without additional tools). For example, you will learn what Map-Reduce is and when to use it to extract more value from your data.
 
-* [Lesson 1: Getting started with indexes](src/unit2/lesson1)
-* [Lesson 2: Creating an index and querying it](src/unit2/lesson2)
-* [Lesson 3: Multi-map indexes](src/unit2/lesson3)
-* [Lesson 4: Mapping(, filtering) and reducing](src/unit2/lesson4)
-* [Lesson 5: The powerful LoadDocument server-side function](src/unit2/lesson5)
-* [Lesson 6: Goodbye Transformers, Welcome Server-side Projections](src/unit2/lesson6)
+* [Lesson 1: Getting started with indexes](src/Unit-2/lesson1)
+* [Lesson 2: Creating an index and querying it](src/Unit-2/lesson2)
+* [Lesson 3: Multi-map indexes](src/Unit-2/lesson3)
+* [Lesson 4: Mapping(, filtering) and reducing](src/Unit-2/lesson4)
+* [Lesson 5: The powerful LoadDocument server-side function](src/Unit-2/lesson5)
+* [Lesson 6: Goodbye Transformers, Welcome Server-side Projections](src/Unit-2/lesson6)
 * [Lesson 7: Statistics and some words about stale indexes!](src/Unit-2/lesson7)
 
 ### Unit 3 - Almost advanced!
@@ -50,13 +50,13 @@ In Unit 3, you will learn some advanced RavenDB features.
 
 You don’t need to know these features in your daily work, but you can use this knowledge to build powerful solutions, obtain better performance, improve safety or create truly reactive user interfaces.
 
-* [Lesson 1: Revisions](src/unit3/lesson1)
-* [Lesson 2: Document Metadata](src/unit3/lesson2)
-* [Lesson 3: Getting started with Operations and Commands!](src/unit3/lesson3)
-* [Lesson 4: Performing batch operations](src/unit3/lesson4)
-* [Lesson 5: I am going through changes ...](src/unit/lesson5)
-* [Lesson 6: Data Subscriptions - I would like to be notified when happens, pls](src/unit3/lesson6)
+* [Lesson 1: Revisions](src/Unit-3/lesson1)
+* [Lesson 2: Document Metadata](src/Unit-3/lesson2)
+* [Lesson 3: Getting started with Operations and Commands!](src/Unit-3/lesson3)
+* [Lesson 4: Performing batch operations](src/Unit-3/lesson4)
+* [Lesson 5: I am going through changes ...](src/Unit-3/lesson5)
+* [Lesson 6: Data Subscriptions - I would like to be notified when happens, pls](src/Unit-3/lesson6)
 
-[Let's begin!](src/unit1/lesson1)
+[Let's begin!](src/Unit-1/lesson1)
 
 That’s it. Enjoy the RavenDB bootcamp and feel free to share your feedback with us.

--- a/README.md
+++ b/README.md
@@ -23,12 +23,11 @@ In Unit 1, you will learn the fundamentals of RavenDB.
 First, you will learn how to install and make it work on your machine. As you will see, RavenDB makes starting easy by providing an embedded sample database – if you think "Northwind", you are right! – which you can use for your learning process with minimal effort. Then, you will write some code to connect to the database and quickly store, load, modify and delete documents.
 
 * [Lesson 1: Getting Started](src/Unit-1/lesson1)
-* [Lesson 2: It is querying time!](src/Unit-1/lesson2)
-* [Lesson 3: Let's code](src/Unit-1/lesson3)
-* [Lesson 4: Basics of DocumentStore](src/Unit-1/lesson4)
-* [Lesson 5: Loading Documents](src/Unit-1/lesson5)
-* [Lesson 6: Querying fundamentals in the C# side] (src/Unit-1/lesson6)
-* [Lesson 7: Storing, modifying and deleting documents](src/Unit-1/lesson7)
+* [Lesson 3: Let's code](src/Unit-1/lesson2)
+* [Lesson 4: Basics of DocumentStore](src/Unit-1/lesson3)
+* [Lesson 5: Loading Documents](src/Unit-1/lesson4)
+* [Lesson 6: Querying fundamentals in the C# side](src/Unit-1/lesson5)
+* [Lesson 7: Storing, modifying and deleting documents](src/Unit-1/lesson6)
 
 ### Unit 2 - Beyond the basics
 

--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ In Unit 1, you will learn the fundamentals of RavenDB.
 First, you will learn how to install and make it work on your machine. As you will see, RavenDB makes starting easy by providing an embedded sample database – if you think "Northwind", you are right! – which you can use for your learning process with minimal effort. Then, you will write some code to connect to the database and quickly store, load, modify and delete documents.
 
 * [Lesson 1: Getting Started](src/Unit-1/lesson1)
-* [Lesson 3: Let's code](src/Unit-1/lesson2)
-* [Lesson 4: Basics of DocumentStore](src/Unit-1/lesson3)
-* [Lesson 5: Loading Documents](src/Unit-1/lesson4)
-* [Lesson 6: Querying fundamentals in the C# side](src/Unit-1/lesson5)
-* [Lesson 7: Storing, modifying and deleting documents](src/Unit-1/lesson6)
+* [Lesson 2: Let's code](src/Unit-1/lesson2)
+* [Lesson 3: Basics of DocumentStore](src/Unit-1/lesson3)
+* [Lesson 4: Loading Documents](src/Unit-1/lesson4)
+* [Lesson 5: Querying fundamentals in the C# side](src/Unit-1/lesson5)
+* [Lesson 6: Storing, modifying and deleting documents](src/Unit-1/lesson6)
 
 ### Unit 2 - Beyond the basics
 
@@ -49,12 +49,11 @@ In Unit 3, you will learn some advanced RavenDB features.
 
 You don’t need to know these features in your daily work, but you can use this knowledge to build powerful solutions, obtain better performance, improve safety or create truly reactive user interfaces.
 
-* [Lesson 1: Revisions](src/Unit-3/lesson1)
-* [Lesson 2: Document Metadata](src/Unit-3/lesson2)
-* [Lesson 3: Getting started with Operations and Commands!](src/Unit-3/lesson3)
-* [Lesson 4: Performing batch operations](src/Unit-3/lesson4)
-* [Lesson 5: I am going through changes ...](src/Unit-3/lesson5)
-* [Lesson 6: Data Subscriptions - I would like to be notified when happens, pls](src/Unit-3/lesson6)
+* [Lesson 1: Document Metadata](src/Unit-3/lesson1)
+* [Lesson 2: Getting started with Operations and Commands!](src/Unit-3/lesson2)
+* [Lesson 3: Performing batch operations](src/Unit-3/lesson3)
+* [Lesson 4: I am going through changes ...](src/Unit-3/lesson4)
+* [Lesson 5: Data Subscriptions - I would like to be notified when happens, pls](src/Unit-3/lesson5)
 
 [Let's begin!](src/Unit-1/lesson1)
 


### PR DESCRIPTION
Links to lessons on start page don't work at the moment, because folder names are changed. I fixed them.