### PR TITLE
Fixes minimum number of documents accordingly to code example

### DIFF
--- a/src/unit1/lesson2/README.md
+++ b/src/unit1/lesson2/README.md
@@ -166,7 +166,7 @@ select count() as Count, key() as Company
 ```
 
 Here, we are grouping the Orders using the Company field as a 
-grouping key. We are adding a filter to get only groups with five documents
+grouping key. We are adding a filter to get only groups with six documents
 at least, then ordering these groups by the number of elements in descending
 order. Finally, we are projecting the number of documents per group and the
 group key.


### PR DESCRIPTION
I think that "greater than 5" (>5 in code example) means "six documents at least" (i.e. >=6)